### PR TITLE
Simplifica deepcopy

### DIFF
--- a/mcts/src/mcts/ia.py
+++ b/mcts/src/mcts/ia.py
@@ -29,11 +29,9 @@ class IA:
         self.arvore = No()
 
     def escolhe_jogada(self, jogo: Jogo) -> tuple[int, int]:
-        jogo_inicial = deepcopy(jogo)
-
         for _ in range(self.max_iteracoes):
             no_atual: No = self.arvore
-            jogo_atual: Jogo = deepcopy(jogo_inicial)
+            jogo_atual: Jogo = deepcopy(jogo)
 
             no_atual = self.selecao(no_atual, jogo_atual)
             no_atual = self.expansao(no_atual, jogo_atual)


### PR DESCRIPTION
No método `escolhe_jogada`, a variável `jogo` é usada apenas no `deepcopy`, guardada uma cópia em `jogo_inicial`, que também só é usada para fazer outro `deepcopy`. Desta forma, assumindo que não existe nenhuma alteração no conteúdo das variáveis `jogo` e `jogo_inicial` dentro dessa função, é possível fazer o `deepcopy` para a variável `jogo_atual` direto da variável `jogo`, tornando desnecessário o primeiro `deepcopy`.

Do que eu testei, o algoritmo continua funcionando normalmente.