### PR TITLE
Configura EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Adiciona a configuração do [EditorConfig](https://editorconfig.org/) ao projeto. Ele é bom para configurar o editor automaticamente, como formato da quebra de linha e indentação, evitando assim de alguém usar um editor com outra configuração e desformatar os arquivos. Além disso, ele faz algumas coisas úteis, como remover espaços em branco no final da linha e colocar uma quebra de linha no final do arquivo.