### PR TITLE
Trata lock do poetry como binário

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+poetry.lock binary diff


### PR DESCRIPTION
Configura o git para tratar o aquivo `poetry.lock` como binário, desta forma ele não tentará resolver conflitos automaticamente, que caso contrário vai torná-lo inválido devido à mudança do conteúdo não bater com o hash na linha `content-hash`, quebrando comando como `poetry install`, por exemplo.