### PR TITLE
Evita conversões duplicadas de jogadas

### DIFF
--- a/src/mcts/ia.py
+++ b/src/mcts/ia.py
@@ -77,7 +77,7 @@ class IA:
         if jogo.acabou():
             return no
 
-        jogadas = set(jogo.lista_jogadas()).difference(no.filhos.keys())
+        jogadas = jogo.lista_jogadas().difference(no.filhos.keys())
         jogada_escolhida = choice(list(jogadas))
 
         no.adiciona_filho(jogada_escolhida)
@@ -88,7 +88,7 @@ class IA:
     def simulacao(self, jogo: Jogo) -> float:
         while not jogo.acabou():
             jogadas = jogo.lista_jogadas()
-            jogada_escolhida = choice(jogadas)
+            jogada_escolhida = choice(list(jogadas))
 
             jogo.joga(jogada_escolhida)
 

--- a/src/mcts/jogo.py
+++ b/src/mcts/jogo.py
@@ -12,9 +12,9 @@ class Jogo:
         self.tabuleiro: list[list[bool | None]] = [[None for j in range(self.tamanho)] for i in range(self.tamanho)]
         self.jogadas: set[tuple[int, int]] = {(i, j) for j in range(self.tamanho) for i in range(self.tamanho)}
 
-    def lista_jogadas(self) -> list[tuple[int, int]]:
+    def lista_jogadas(self) -> set[tuple[int, int]]:
         if not self.terminou:
-            return list(self.jogadas)
+            return self.jogadas
 
         raise Exception('O jogo já terminou.')
 


### PR DESCRIPTION
Evita converter as jogadas possíveis de um `set` para um `list` e depois converter para `set` de novo.