### PR TITLE
Atualiza poetry (2.1.4)

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -10,7 +10,7 @@ echo '. <(pip completion --bash)' > ~/.local/share/bash-completion/completions/p
 echo '. <(register-python-argcomplete pipx)' > ~/.local/share/bash-completion/completions/pipx
 
 # Configura poetry
-pipx install poetry==2.1.3
+pipx install poetry==2.1.4
 poetry config virtualenvs.in-project true
 [ -e .venv ] || poetry env use /usr/local/bin/python
 echo '.  <(poetry completions bash)' > ~/.local/share/bash-completion/completions/poetry

--- a/.github/workflows/valida-commit.yml
+++ b/.github/workflows/valida-commit.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Instala poetry
-        run: pipx install poetry==2.1.3
+        run: pipx install poetry==2.1.4
 
       - name: Instala python
         id: setup-python


### PR DESCRIPTION
O comando `poetry sync` está falhando no GitHub Actions devido a uma questão com o pacote `virtualenv`:
- https://github.com/python-poetry/poetry/issues/10490

A correção já foi feita, porém é necessário atualizar o poetry para que o CI volte a funcionar como o esperado.